### PR TITLE
Update plugin.xml to enable plugin for all products

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -18,9 +18,8 @@
 
     <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->
-    <!-- uncomment to enable plugin in all products
+    <!-- uncomment to enable plugin in all products-->
     <depends>com.intellij.modules.lang</depends>
-    -->
 
     <application-components>
         <!-- Add your application components here -->


### PR DESCRIPTION
Adds a module dependency tag so that other IDEA products (including CLion) will load the plugin. Otherwise IntelliJ refuses with legacy plugin error.